### PR TITLE
Adding multiple override broker snippets files

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,12 @@ It is possible to mount a whole artemis `etc` directory in this image in the vol
 But this is an overkill for many situations where only small tweaks are necessary.  
 
 For those cases `/var/lib/artemis/etc-override` can be used.
-If a `broker.xml` file is present, it will be *merged* with the default configuration.
 
-For instance lets say that you want to add a diverts section, you could have a local directory, lets say `/var/artemis-data/override`
-where you could place a broker.xml file that looks like the following listing:
+Multiple files with snippets of configuration can be dropped in the `etc-override` folder. Those configuration files must be named following the name convention `broker-{{desc}}.xml` where `desc` is a numeric representation of the snippet.
+The configuration files will be *merged* with the default configuration. An alphabetical precedence of the file names will be considered for the merge and in case of collision the latest change will be treated as final.
+
+For instance lets say that you want to add a diverts section, you could have a local directory, lets say `/var/artemis-data/etc-override`
+where you could place a `broker-00.xml` file that looks like the following listing:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
@@ -128,7 +130,7 @@ where you could place a broker.xml file that looks like the following listing:
 </configuration>
 ```
 
-For the use cases where instead of merging, the desired outcome is an override, a file named `custom-transformations.xslt`
+For the use cases where instead of merging, the desired outcome is an override, a file named `broker-00.xslt`
 in `/var/lib/artemis/etc-override` is supported. For instance to delete override the `jms` definitions instead of merging, these files could be used:
 
 `broker.xml`
@@ -144,7 +146,7 @@ in `/var/lib/artemis/etc-override` is supported. For instance to delete override
 </configuration>
 ```
 
-`custom-transformations.xslt`
+`broker-00.xslt`
 
 ```xslt
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,10 @@ set -e
 # Log to tty to enable docker logs container-name
 sed -i "s/logger.handlers=.*/logger.handlers=CONSOLE/g" ../etc/logging.properties
 
+BROKER_HOME=/var/lib/artemis/
+OVERRIDE_PATH=$BROKER_HOME/etc-override
+CONFIG_PATH=$BROKER_HOME/etc
+
 # Update users and roles with if username and password is passed as argument
 if [[ "$ARTEMIS_USERNAME" && "$ARTEMIS_PASSWORD" ]]; then
   sed -i "s/amq[ ]*=.*/amq=$ARTEMIS_USERNAME\n/g" ../etc/artemis-roles.properties
@@ -20,19 +24,22 @@ if [[ "$ARTEMIS_MAX_MEMORY" ]]; then
   sed -i "s/-Xmx1024M/-Xmx$ARTEMIS_MAX_MEMORY/g" ../etc/artemis.profile
 fi
 
-if [ -f /var/lib/artemis/etc-override/broker.xslt ]; then
-  echo Applying broker.xslt
-  cp /var/lib/artemis/etc/broker.xml /tmp/broker.xml
-  xmlstarlet tr /var/lib/artemis/etc-override/broker.xslt /tmp/broker.xml > /var/lib/artemis/etc/broker.xml
+files=$(find $OVERRIDE_PATH -name "broker*" -type f | cut -d. -f1 | sort -u );
+if [ ${#files[@]} ]; then
+  cp $CONFIG_PATH/broker.xml /tmp/broker.xml
+  for f in $files; do
+    if [ -f $f.xslt ]; then
+      xmlstarlet tr $f.xslt /tmp/broker.xml > /tmp/broker-tr.xml
+      mv /tmp/broker-tr.xml /tmp/broker.xml
+    fi
+    if [ -f $f.xml ]; then
+      xmlstarlet tr /opt/merge/merge.xslt -s replace=true -s with=$f.xml /tmp/broker.xml > /tmp/broker-merge.xml
+      mv /tmp/broker-merge.xml /tmp/broker.xml
+    fi
+  done
+  cp /tmp/broker.xml $CONFIG_PATH/broker.xml
 else
-  echo No broker.xslt found
-fi
-
-if [ -f /var/lib/artemis/etc-override/broker.xml ]; then
-  cp /var/lib/artemis/etc/broker.xml /tmp/broker.xml
-  xmlstarlet tr /opt/merge/merge.xslt -s with=/var/lib/artemis/etc-override/broker.xml /tmp/broker.xml > /var/lib/artemis/etc/broker.xml
-else
-  echo No broker.xml override found
+  echo No configuration snippets found
 fi
 
 function performance-journal {


### PR DESCRIPTION
Changes to support https://github.com/vromero/activemq-artemis-docker/issues/15:

* Added Variables to reduce path rewrite
* Iterate across multiple `broker-{{desc}}.xml` files of the `etc-override` folder and apply the configuration. 
* Added the replace param.