### PR TITLE
Add option to enable CORS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN chown -R artemis.artemis /var/lib/artemis
 RUN mkdir -p /opt/assets
 COPY assets/merge.xslt /opt/assets
 COPY assets/enable-jmx.xml /opt/assets
+COPY assets/jolokia-cors.xslt /opt/assets
 
 # Web Server
 EXPOSE 8161

--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ Given that JMX is intended for side cars, it is attached only to localhost and n
 $ docker run -d -e ENABLE_JMX=true -e JMX_PORT=1199 -e JMX_RMI_PORT=1198 vromero/activemq-artemis
 ```
 
+## Configuring CORS
+
+By default, [Jolokia security](https://jolokia.org/reference/html/security.html) only allows access to the management console and REST API from localhost.
+To access them from the network, you can configure [Cross-Origin Resource Sharing](https://www.w3.org/TR/cors/) using the environment variable `JOLOKIA_ALLOW_ORIGIN`.
+The default value is `*://localhost*`.
+
+For example, to allow access from any domain:
+
+```console
+$ docker run -d -e JOLOKIA_ALLOW_ORIGIN='*' vromero/activemq-artemis
+```
+
 ## Performing a performance journal test
 
 Different kinds of volumes need different values in fine tuning.

--- a/assets/jolokia-cors.xslt
+++ b/assets/jolokia-cors.xslt
@@ -1,0 +1,17 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <xsl:output encoding="utf-8"/>
+
+    <xsl:param name="origin"/>
+
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="restrict/cors/allow-origin/text()">
+        <xsl:value-of select="$origin"/>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -55,6 +55,12 @@ EOF
   mv /tmp/broker-merge.xml $CONFIG_PATH/broker.xml
 fi
 
+if [[ "$JOLOKIA_ALLOW_ORIGIN" ]]; then
+  cp $CONFIG_PATH/jolokia-access.xml /tmp/jolokia-access.xml
+  xmlstarlet tr /opt/assets/jolokia-cors.xslt -s origin="$JOLOKIA_ALLOW_ORIGIN" /tmp/jolokia-access.xml > /tmp/jolokia-access-cors.xml
+  mv /tmp/jolokia-access-cors.xml $CONFIG_PATH/jolokia-access.xml
+fi
+
 function performance-journal {
   if [[ "$ARTEMIS_PERF_JOURNAL" = "AUTO" || "$ARTEMIS_PERF_JOURNAL" = "ALWAYS" ]]; then
 


### PR DESCRIPTION
Normally you can only access the management console from localhost. This adds a new option for it.