### PR TITLE
Allow passing java arguments to artemis run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN cd /var/lib && \
     --role amq \
     --require-login \
     --cluster-user artemisCluster \
-    --cluster-password simetraehcaparetsulc
+    --cluster-password simetraehcaparetsulc \
+    --java-options '$JAVA_ARGS'
 
 # Ports are only exposed with an explicit argument, there is no need to binding
 # the web console to localhost

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -43,12 +43,7 @@ else
 fi
 
 if [[ "$ENABLE_JMX" ]]; then
-
-  cat << 'EOF' >> $CONFIG_PATH/artemis.profile
-    if [ "$1" = "run" ]; then
-      JAVA_ARGS="$JAVA_ARGS -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=${JMX_PORT:-1099} -Dcom.sun.management.jmxremote.rmi.port=${JMX_RMI_PORT:-1098} -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
-    fi
-EOF
+  JAVA_ARGS="$JAVA_ARGS -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=${JMX_PORT:-1099} -Dcom.sun.management.jmxremote.rmi.port=${JMX_RMI_PORT:-1098} -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
 
   cp $CONFIG_PATH/broker.xml /tmp/broker.xml
   xmlstarlet tr /opt/assets/merge.xslt -s replace=true -s with=/opt/assets/enable-jmx.xml /tmp/broker.xml > /tmp/broker-merge.xml


### PR DESCRIPTION
Honor `JAVA_ARGS` environment variable, e.g.

`docker run -e JAVA_ARGS="-Dbrokerconfig.globalMaxSize=1000000" vromero/activemq-artemis`

It is useful for [passing substitution variables into broker.xml](https://activemq.apache.org/artemis/docs/latest/configuration-index.html), [passing hawtio arguments](http://hawt.io/configuration/index.html), etc. Unfortunately you can't pass -Xms/-Xmx because of the argument ordering in `artemis.profile`.
