### PR TITLE
Use exec to call dumb-init

### DIFF
--- a/src/assets/docker-entrypoint.sh
+++ b/src/assets/docker-entrypoint.sh
@@ -133,7 +133,7 @@ if (echo "${ACTIVEMQ_ARTEMIS_VERSION}" | grep -Eq  "(1.5\\.[3-5]|[^1]\\.[0-9]\\.
 fi
 
 if [ "$1" = 'artemis-server' ]; then
-	dumb-init -- sh ./artemis run
+  exec dumb-init -- sh ./artemis run
 fi
 
 exec "$@"


### PR DESCRIPTION
So that PID 1 is `dumb-init` and not the `entrypoint` script. `docker stop` still gives non-zero exit code with this change. It may be due to how `artemis` handles `SIGTERM`, assuming `dumb-init` correctly passes the signals back and forth.
Also replaced tab with double space for consistency.