### PR TITLE
add ability to add customizations to entrypoint startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ variables, it is recommended to use the partial override mechanism described in 
 
 ### 5.9 Overriding parts of the configuration
 
-The default ActiveMQ Artemis configuration can be partially modified, instead of completely replaced as in the previous section, using two mechanisms. Merge snippets and XSLT tranformations.
+The default ActiveMQ Artemis configuration can be partially modified, instead of completely replaced as in the previous section, using three mechanisms. Merge snippets, XSLT tranformations and entrypoint overrides.
 
 **Merging snippets**
 
@@ -341,6 +341,14 @@ A file name `broker-00.xslt` with content like the following listing, could be u
     <xsl:template match="*[local-name()='jms']"/>
 </xsl:stylesheet>
 ```
+
+**Entrypoint Overrides**
+
+Multiple shell scripts can be dropped in the `/var/lib/artemis/etc-override` volume. Those shell files must be named following the name convention `entrypoint-{{num}}.xml` where `num` is a numeric representation of the snippet.
+The shell scripts will be *executed* in alphabetical precedence of the file names on startup of the docker container.   
+
+A typical use case for using entrypoint overrides would be if you want to make a minor modification to a file which cannot be overriden using the 2 methods above and you do not want to expose the etc volume. 
+
 
 If you would like to see the final result of your transformations, execute the following:
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -112,6 +112,7 @@ RUN apt-get -qq -o=Dpkg::Use-Pty=0 update && \
     libaio1=0.3.110-3 \
     xmlstarlet=1.6.1-2 \
     jq=1.5+dfsg-1.3 \
+    gettext-base=0.19.8.1-2 \
     dumb-init=1.2.0-1 && \
   rm -rf /var/lib/apt/lists/*
 

--- a/src/Dockerfile.alpine
+++ b/src/Dockerfile.alpine
@@ -109,7 +109,7 @@ RUN addgroup -g 1000 -S artemis && adduser -u 1000 -S -G artemis artemis
 
 # Sadly this line is likely to fail every so often, see: https://medium.com/@stschindler/the-problem-with-docker-and-alpines-package-pinning-18346593e891
 # Still versions are pinned to maintain some small level of https://reproducible-builds.org/
-RUN apk add --no-cache libaio=0.3.111-r0 xmlstarlet=1.6.1-r0 jq=1.6_rc1-r1 dumb-init=1.2.1-r0 sed=4.4-r2
+RUN apk add --no-cache libaio=0.3.111-r0 xmlstarlet=1.6.1-r0 jq=1.6_rc1-r1 dumb-init=1.2.1-r0 sed=4.4-r2 gettext=0.19.8.1-r2
 
 COPY --from=builder "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}" "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}"
 COPY --from=builder "/var/lib/artemis" "/var/lib/artemis"

--- a/src/assets/docker-entrypoint.sh
+++ b/src/assets/docker-entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 BROKER_HOME=/var/lib/artemis
 OVERRIDE_PATH=$BROKER_HOME/etc-override
 CONFIG_PATH=$BROKER_HOME/etc
+export BROKER_HOME OVERRIDE_PATH CONFIG_PATH
 
 # In case this is running in a non standard system that automounts
 # empty volumes like OpenShift, restore the configuration into the 
@@ -146,6 +147,14 @@ do
 done < /tmp/brokerconfigs.txt
 rm -f /tmp/brokerconfigs.txt
 export BROKER_CONFIGS
+
+files=$(find $OVERRIDE_PATH -name "entrypoint*.sh" -type f | sort -u );
+if [ ${#files[@]} ]; then
+  for f in $files; do
+    echo "Processing entrypoint override: $f"
+    /bin/sh "$f"
+  done
+fi
 
 if [ "$1" = 'artemis-server' ]; then
   exec dumb-init -- sh ./artemis run

--- a/test/1.x.x/etc-override/entrypoint-00.sh
+++ b/test/1.x.x/etc-override/entrypoint-00.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+touch /var/lib/artemis/etc/created_by_entrypoint-00

--- a/test/2.x.x/etc-override/entrypoint-00.sh
+++ b/test/2.x.x/etc-override/entrypoint-00.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+touch /var/lib/artemis/etc/created_by_entrypoint-00

--- a/test/goss.yaml
+++ b/test/goss.yaml
@@ -167,3 +167,10 @@ file:
       - "-Dcom.sun.management.jmxremote.authenticate=false"
   {{end}}
 {{end}}
+
+{{if (.Vars.flags.testmerge) }}
+  /var/lib/artemis/etc/created_by_entrypoint-00:
+    exists: true
+    owner: artemis
+    group: artemis
+{{end}}


### PR DESCRIPTION
allow the ability to customize the startup behavior when needed.  gettext was added so that we can use envsubst in the entrypoint-xx.sh if needed.