### PR TITLE
fix duplicate jmx enablement issue on restart

### DIFF
--- a/src/assets/docker-entrypoint.sh
+++ b/src/assets/docker-entrypoint.sh
@@ -91,12 +91,12 @@ else
 fi
 
 if [ "$ENABLE_JMX" ] || [ "$ENABLE_JMX_EXPORTER" ]; then
-  sed -i "s/^JAVA_ARGS=\"/JAVA_ARGS=\"-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=${JMX_PORT:-1099} -Dcom.sun.management.jmxremote.rmi.port=${JMX_RMI_PORT:-1098} -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false /g" $CONFIG_PATH/artemis.profile
+  sed -i "/com.sun.management.jmxremote/!s/^JAVA_ARGS=\"/JAVA_ARGS=\"-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=${JMX_PORT:-1099} -Dcom.sun.management.jmxremote.rmi.port=${JMX_RMI_PORT:-1098} -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false /g" $CONFIG_PATH/artemis.profile
   mergeXmlFiles "$CONFIG_PATH/broker.xml" /opt/assets/enable-jmx.xml "$CONFIG_PATH/broker.xml"
 fi
 
 if [ "$ENABLE_JMX_EXPORTER" ]; then
-  sed -i "s/^JAVA_ARGS=\"/JAVA_ARGS=\"-javaagent:\\/opt\\/jmx-exporter\\/jmx_prometheus_javaagent.jar=9404:\\/opt\\/jmx-exporter\\/jmx-exporter-config.yaml /g" $CONFIG_PATH/artemis.profile
+  sed -i "/jmx_prometheus_javaagent.jar/!s/^JAVA_ARGS=\"/JAVA_ARGS=\"-javaagent:\\/opt\\/jmx-exporter\\/jmx_prometheus_javaagent.jar=9404:\\/opt\\/jmx-exporter\\/jmx-exporter-config.yaml /g" $CONFIG_PATH/artemis.profile
 fi
 
 if [ -e /var/lib/artemis/etc/jolokia-access.xml ]; then


### PR DESCRIPTION
If you restart a docker container that has `ENABLE_JMX_EXPORTER=true` the result is that the jmxagent parameters get added multiple times to the artemis.profile which causes the broker to fail to start with the following error.   This PR prevents the issue from occurring.
```
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:386)
	at sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:401)
Caused by: java.lang.IllegalArgumentException: Collector already registered that provides name: jmx_scrape_duration_seconds
	at io.prometheus.jmx.shaded.io.prometheus.client.CollectorRegistry.register(CollectorRegistry.java:54)
	at io.prometheus.jmx.shaded.io.prometheus.client.Collector.register(Collector.java:139)
	at io.prometheus.jmx.shaded.io.prometheus.client.Collector.register(Collector.java:132)
	at io.prometheus.jmx.shaded.io.prometheus.jmx.JavaAgent.premain(JavaAgent.java:47)
	... 6 more
FATAL ERROR in native method: processing of -javaagent failed
```