### PR TITLE
Delete security-enabled section before adding

### DIFF
--- a/src/assets/docker-entrypoint.sh
+++ b/src/assets/docker-entrypoint.sh
@@ -19,6 +19,11 @@ if [ "$DISABLE_SECURITY" ]; then
     xmlstarlet ed -L \
       -N activemq="urn:activemq" \
       -N core="urn:activemq:core" \
+      -d "/activemq:configuration/core:core/core:security-enabled" \
+      ../etc/broker.xml
+    xmlstarlet ed -L \
+      -N activemq="urn:activemq" \
+      -N core="urn:activemq:core" \
       --subnode "/activemq:configuration/core:core" \
       -t elem \
       -n "security-enabled" \


### PR DESCRIPTION
When `DISABLE_SECURITY=true` `docker-entrypoint.sh` now deletes the `<security-enabled>` tags before adding one, since having more than one of these elements prevents start-up.

Addresses #104