### PR TITLE
Fix issue #146 Alpine artemis-service start fails with error

### DIFF
--- a/src/Dockerfile.alpine
+++ b/src/Dockerfile.alpine
@@ -137,7 +137,8 @@ RUN apk add --no-cache \
   jq=1.6-r0 \
   dumb-init=1.2.2-r1 \
   sed=4.5-r0 \
-  gettext=0.19.8.1-r4
+  gettext=0.19.8.1-r4 \
+  procps=3.3.15-r0
 
 COPY --from=builder "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}" "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}"
 COPY --from=builder "/var/lib/artemis" "/var/lib/artemis"


### PR DESCRIPTION
Fix tested using the same reproduction instructions found in https://github.com/vromero/activemq-artemis-docker/issues/146
