### PR TITLE
Fix 'AMQ229224: User artemis does not exist' when restarting container

### DIFF
--- a/src/assets/docker-entrypoint.sh
+++ b/src/assets/docker-entrypoint.sh
@@ -56,11 +56,11 @@ if [ "$ARTEMIS_USERNAME" ] && [ "$ARTEMIS_PASSWORD" ]; then
   if echo "${ACTIVEMQ_ARTEMIS_VERSION}" | grep -Eq "1.[0-4].[0-9]" ; then
     sed -i "s/artemis[ ]*=.*/$ARTEMIS_USERNAME=$ARTEMIS_PASSWORD\\n/g" ../etc/artemis-users.properties
   else
-    if ${BROKER_HOME}/bin/artemis user list | grep -Eq \"artemis\" ; then
+    if ${BROKER_HOME}/bin/artemis user list | grep -Eq "\"artemis\"" ; then
       $BROKER_HOME/bin/artemis user rm --user artemis
     fi
-    if ${BROKER_HOME}/bin/artemis user list | grep -Eq \"${ARTEMIS_USERNAME}\" ; then
-      $BROKER_HOME/bin/artemis user rm --user $ARTEMIS_USERNAME
+    if ${BROKER_HOME}/bin/artemis user list | grep -Eq "\"${ARTEMIS_USERNAME}\"" ; then
+      $BROKER_HOME/bin/artemis user rm --user "$ARTEMIS_USERNAME"
     fi
     $BROKER_HOME/bin/artemis user add --user "$ARTEMIS_USERNAME" --password "$ARTEMIS_PASSWORD" --role amq
   fi

--- a/src/assets/docker-entrypoint.sh
+++ b/src/assets/docker-entrypoint.sh
@@ -56,7 +56,12 @@ if [ "$ARTEMIS_USERNAME" ] && [ "$ARTEMIS_PASSWORD" ]; then
   if echo "${ACTIVEMQ_ARTEMIS_VERSION}" | grep -Eq "1.[0-4].[0-9]" ; then
     sed -i "s/artemis[ ]*=.*/$ARTEMIS_USERNAME=$ARTEMIS_PASSWORD\\n/g" ../etc/artemis-users.properties
   else
-    $BROKER_HOME/bin/artemis user rm --user artemis
+    if ${BROKER_HOME}/bin/artemis user list | grep -Eq \"artemis\" ; then
+      $BROKER_HOME/bin/artemis user rm --user artemis
+    fi
+    if ${BROKER_HOME}/bin/artemis user list | grep -Eq \"${ARTEMIS_USERNAME}\" ; then
+      $BROKER_HOME/bin/artemis user rm --user $ARTEMIS_USERNAME
+    fi
     $BROKER_HOME/bin/artemis user add --user "$ARTEMIS_USERNAME" --password "$ARTEMIS_PASSWORD" --role amq
   fi
 fi


### PR DESCRIPTION
When `ARTEMIS_USERNAME` and `ARTEMIS_PASSWORD` environment variables are set, default user `artemis` is deleted when the container starts for the first time. Subsequent restarts then fail when trying to delete the non-existing (because already deleted) user `artemis`.

This commit checks whether the user exists before trying to delete it, enabling the container to be restarted.

This commit also deletes any existing `ARTEMIS_USERNAME`, enabling its password to be changed.