### PR TITLE
Add support for a JDK 11 based image 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,14 @@ env:
   - VERSION=1.0.0 VARIANT=alpine
   - VERSION=1.1.0
   - VERSION=1.1.0 VARIANT=alpine
-  - VERSION=1.2.0 
+  - VERSION=1.2.0
   - VERSION=1.2.0 VARIANT=alpine
-  - VERSION=1.3.0 
+  - VERSION=1.3.0
   - VERSION=1.3.0 VARIANT=alpine
-  - VERSION=1.4.0 
+  - VERSION=1.4.0
   - VERSION=1.4.0 VARIANT=alpine
   - VERSION=1.5.0
-  - VERSION=1.5.0 VARIANT=alpine 
+  - VERSION=1.5.0 VARIANT=alpine
   - VERSION=1.5.1
   - VERSION=1.5.1 VARIANT=alpine
   - VERSION=1.5.2
@@ -24,48 +24,49 @@ env:
   - VERSION=1.5.4 VARIANT=alpine
   - VERSION=1.5.5
   - VERSION=1.5.5 VARIANT=alpine
-  - VERSION=1.5.6 
+  - VERSION=1.5.6
   - VERSION=1.5.6 VARIANT=alpine
-  - VERSION=2.0.0 
+  - VERSION=2.0.0
   - VERSION=2.0.0 VARIANT=alpine
-  - VERSION=2.1.0 
+  - VERSION=2.1.0
   - VERSION=2.1.0 VARIANT=alpine
-  - VERSION=2.2.0 
+  - VERSION=2.2.0
   - VERSION=2.2.0 VARIANT=alpine
-  - VERSION=2.3.0 
+  - VERSION=2.3.0
   - VERSION=2.3.0 VARIANT=alpine
-  - VERSION=2.4.0 
+  - VERSION=2.4.0
   - VERSION=2.4.0 VARIANT=alpine
-  - VERSION=2.5.0 
+  - VERSION=2.5.0
   - VERSION=2.5.0 VARIANT=alpine
   - VERSION=2.6.0
   - VERSION=2.6.0 VARIANT=alpine
   - VERSION=2.6.1
   - VERSION=2.6.1 VARIANT=alpine
   - VERSION=2.6.2
-  - VERSION=2.6.2 VARIANT=alpine    
-  - VERSION=2.6.3 
+  - VERSION=2.6.2 VARIANT=alpine
+  - VERSION=2.6.3
   - VERSION=2.6.3 VARIANT=alpine
-  - VERSION=2.7.0 
+  - VERSION=2.7.0
   - VERSION=2.7.0 VARIANT=alpine
-  - VERSION=2.8.0 
+  - VERSION=2.8.0
   - VERSION=2.8.0 VARIANT=alpine
-  - VERSION=2.9.0 
+  - VERSION=2.9.0
   - VERSION=2.9.0 VARIANT=alpine
   - VERSION=2.10.0
   - VERSION=2.10.0 VARIANT=alpine
-  - VERSION=2.10.1 
+  - VERSION=2.10.1
   - VERSION=2.10.1 VARIANT=alpine
-  - VERSION=2.11.0 
+  - VERSION=2.11.0
   - VERSION=2.11.0 VARIANT=alpine
-  - VERSION=2.12.0 
+  - VERSION=2.12.0
   - VERSION=2.12.0 VARIANT=alpine
-  - VERSION=2.13.0 
+  - VERSION=2.13.0
   - VERSION=2.13.0 VARIANT=alpine
-  - VERSION=2.14.0 
+  - VERSION=2.14.0
   - VERSION=2.14.0 VARIANT=alpine
   - VERSION=2.15.0
   - VERSION=2.15.0 VARIANT=alpine
+  - VERSION=2.15.0 VARIANT=jdk11
 
 before_install:
   - curl -L https://goss.rocks/install | sudo sh
@@ -82,11 +83,10 @@ script:
     (
       set -Eeuo pipefail
       set -x
-      travis_retry make $versionTag 
+      travis_retry make $versionTag
       echo ---------------------------
       echo $TRAVIS_PULL_REQUEST
       echo $TRAVIS_BRANCH
       echo ---------------------------
       if [[ $TRAVIS_PULL_REQUEST == "false" ]] && [[ $TRAVIS_BRANCH == "master" ]]; then travis_retry make push_$versionTag; fi
     )
-

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ALL_VERSION_TAGS=$(shell awk -F "," 'NR>1  {print $$2}' ${VERSIONS_FILE})
 lookupFromTag=$(shell awk -F "," '$$2 == "$1" {print $$$2}' ${VERSIONS_FILE})
 lookupRepositoryFromTag=$(call lookupFromTag,$1, 1)
 lookupBaseImageFromTag=$(call lookupFromTag,$1, 3)
-lookupÀliasesFromTag=$(call lookupFromTag,$1, 4)
+lookupAliasesFromTag=$(call lookupFromTag,$1, 4)
 lookupDockerfileFromTag=$(call lookupFromTag,$1, 5)
 
 getPart=$(word $2,$(subst -, ,$1))
@@ -16,7 +16,6 @@ getVariantFromTag=$(call getPart,$1, 2)
 getFullTagNameFromTag=$(call lookupRepositoryFromTag,$1):$(call getVersionFromTag,$1)$(if $(call getVariantFromTag,$1),-$(call getVariantFromTag,$1),"")
 
 %: build_% test_% tag_%
-	
 
 build_%:
 	@cd src && \
@@ -24,11 +23,11 @@ build_%:
 	docker build --quiet --build-arg ACTIVEMQ_ARTEMIS_VERSION=$(call getVersionFromTag,$*) --build-arg BASE_IMAGE=$(call lookupBaseImageFromTag,$*) $(BUILD_ARGS) -t $(call getFullTagNameFromTag,$*) -f $(call lookupDockerfileFromTag,$*) .
 
 tag_%:
-	@for alias in $(call lookupÀliasesFromTag,$*); do docker tag $(call getFullTagNameFromTag,$*) $$alias ; done
+	@for alias in $(call lookupAliasesFromTag,$*); do docker tag $(call getFullTagNameFromTag,$*) $$alias ; done
 
 push_%:
 	@docker push $(call getFullTagNameFromTag,$*)
-	@for alias in $(call lookupÀliasesFromTag,$*); do docker push $$alias ; done
+	@for alias in $(call lookupAliasesFromTag,$*); do docker push $$alias ; done
 
 run_%: build
 	docker run -i -t --rm $(call getFullTagNameFromTag,$*)
@@ -41,5 +40,3 @@ all: $(ALL_VERSION_TAGS)
 test_%:
 	@DOCKER_FILE=$(call lookupDockerfileFromTag,$*) COORDINATES=$(call getFullTagNameFromTag,$*) TAG=$* bats test/*.bats
 	@echo
-
-	

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 | Debian Based                                                                                 | Alpine Based                                                                                               |
 |--------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| [`latest`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile) | [`latest-alpine`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile.alpine) |
-| [`2.15.0`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile)  | [`2.15.0-alpine`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile.alpine)  |
+| [`latest`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile), [`latest-jdk11`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile.jdk11) | [`latest-alpine`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile.alpine) |
+| [`2.15.0`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile), [`2.15.0-jdk11`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile.jdk11)  | [`2.15.0-alpine`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile.alpine)  |
 | [`2.14.0`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile)  | [`2.14.0-alpine`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile.alpine)  |
 | [`2.13.0`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile)  | [`2.13.0-alpine`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile.alpine)  |
 | [`2.12.0`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile)  | [`2.12.0-alpine`](https://raw.githubusercontent.com/vromero/activemq-artemis-docker/master/src/Dockerfile.alpine)  |
@@ -47,9 +47,10 @@
 
 ## 3. About this image
 
-The ActiveMQ Artemis images come in two flavors, both equally supported :
+The ActiveMQ Artemis images come in three flavors, both equally supported :
 
 - **Debian based**: the default one.
+- **Debian based, Java 11**: Java 11 and Debian 10 (Buster).
 - **Alpine based**: much lighter.
 
 All versions of ActiveMQ Artemis are provided for the time being but versions previous to 1.5.5 shall be considered deprecated and could be removed at any time.
@@ -103,7 +104,7 @@ docker run -it --rm \
   -p 8161:8161 \
   -p 61616:61616 \
   vromero/activemq-artemis
-```  
+```
 
 After a few seconds you'll see in the output a block similar to:
 
@@ -293,7 +294,7 @@ Make sure you read the falacy number one of the [falacies of the distributed com
 ### 5.9 Using external configuration files
 
 It is possible to mount a whole artemis `etc` directory in this image in the volume `/var/lib/artemis/etc`.
-Be careful as this might be an overkill for many situations where only small tweaks are necessary.  
+Be careful as this might be an overkill for many situations where only small tweaks are necessary.
 
 When using this technique be aware that the configuration files of Artemis might change from version to version.
 Generally speaking, when in need to configure Artemis beyond what it is offered by this image using environment
@@ -373,7 +374,7 @@ A file name `broker-00.xslt` with content like the following listing, could be u
 **Entrypoint Overrides**
 
 Multiple shell scripts can be dropped in the `/var/lib/artemis/etc-override` volume. Those shell files must be named following the name convention `entrypoint-{{num}}.sh` where `num` is a numeric representation of the snippet.
-The shell scripts will be *executed* in alphabetical precedence of the file names on startup of the docker container.   
+The shell scripts will be *executed* in alphabetical precedence of the file names on startup of the docker container.
 
 A typical use case for using entrypoint overrides would be if you want to make a minor modification to a file which cannot be overriden using the 2 methods above and you do not want to expose the etc volume.
 
@@ -390,7 +391,7 @@ docker run -it --rm \
 ### 5.11 Broker Config
 
 ActiveMQ allows you to override key configuration values using [System properties](https://activemq.apache.org/artemis/docs/latest/configuration-index.html#System-properties).
-This docker image has built in support to set these values by passing environment variables prefixed with BROKER_CONFIG to the docker image.  
+This docker image has built in support to set these values by passing environment variables prefixed with BROKER_CONFIG to the docker image.
 
 Below is an example which overrides the global-max-size and disk-scan-period values
 ```

--- a/src/Dockerfile.jdk11
+++ b/src/Dockerfile.jdk11
@@ -23,7 +23,8 @@ RUN apt-get -qq -o=Dpkg::Use-Pty=0 update && \
     ca-certificates=20200601~deb10u1 \
     wget=1.20.1-1.1 \
     gpg=2.2.12-1+deb10u1 \
-    gpg-agent=2.2.12-1+deb10u1 && \
+    gpg-agent=2.2.12-1+deb10u1 \
+    iputils-ping=3:20180629-2+deb10u1 && \
   rm -rf /var/lib/apt/lists/*
 
 # Make sure pipes are considered to detemine success, see: https://github.com/hadolint/hadolint/wiki/DL4006

--- a/src/Dockerfile.jdk11
+++ b/src/Dockerfile.jdk11
@@ -1,0 +1,198 @@
+# ActiveMQ Artemis
+
+##########################################################
+## Build Image                                           #
+##########################################################
+ARG BASE_IMAGE
+FROM openjdk:11-jdk-slim-buster as builder
+LABEL maintainer="Victor Romero <victor.romero@gmail.com>"
+
+ARG ACTIVEMQ_ARTEMIS_VERSION
+ARG ACTIVEMQ_DISTRIBUTION_URL
+ENV JMX_EXPORTER_VERSION=0.3.1
+ENV JGROUPS_KUBERNETES_VERSION=0.9.3
+
+# See https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get -qq -o=Dpkg::Use-Pty=0 update && \
+  apt-get -qq -o=Dpkg::Use-Pty=0 install -y --no-install-recommends \
+    libaio1=0.3.112-3 \
+    xmlstarlet=1.6.1-2 \
+    jq=1.5+dfsg-2+b1 \
+    ca-certificates=20200601~deb10u1 \
+    wget=1.20.1-1.1 \
+    gpg=2.2.12-1+deb10u1 \
+    gpg-agent=2.2.12-1+deb10u1 && \
+  rm -rf /var/lib/apt/lists/*
+
+# Make sure pipes are considered to detemine success, see: https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Uncompress and validate
+WORKDIR /opt
+RUN if (echo "${ACTIVEMQ_DISTRIBUTION_URL}" | grep -Eq  ".zip\$" ) ; \
+    then \
+      mkdir tmp && \
+      wget "${ACTIVEMQ_DISTRIBUTION_URL}" -P tmp/ && \
+      unzip -d tmp -q "tmp/*.zip" && rm -f tmp/*.zip && ls -l tmp/ && \
+        mv tmp/* ./apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION} && \
+        ln -s "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}" "/opt/apache-artemis" && \
+        rmdir tmp; \
+    elif test -n "${ACTIVEMQ_DISTRIBUTION_URL}" ; \
+    then \
+      echo "Only .zip format is supported when using ACTIVEMQ_DISTRIBUTION_URL" && \
+      exit 2; \
+    else \
+      wget "https://repository.apache.org/content/repositories/releases/org/apache/activemq/apache-artemis/${ACTIVEMQ_ARTEMIS_VERSION}/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}-bin.tar.gz" && \
+      wget "https://repository.apache.org/content/repositories/releases/org/apache/activemq/apache-artemis/${ACTIVEMQ_ARTEMIS_VERSION}/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}-bin.tar.gz.asc" && \
+      wget "http://apache.org/dist/activemq/KEYS" && \
+      gpg --no-tty --import "KEYS" && \
+      gpg --no-tty "apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}-bin.tar.gz.asc" && \
+      tar xfz "apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}-bin.tar.gz" && \
+      ln -s "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}" "/opt/apache-artemis" && \
+      rm -f "apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}-bin.tar.gz" "KEYS" "apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}-bin.tar.gz.asc"; \
+    fi
+
+# Create broker instance
+# Per recommendation of https://activemq.apache.org/artemis/docs/latest/perf-tuning.html : -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -XX:+UseParallelOldGC
+WORKDIR /var/lib
+RUN if test "${ACTIVEMQ_ARTEMIS_VERSION}" = "1.0.0" ; \
+    then \
+      echo n | "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}/bin/artemis" create artemis \
+        --home /opt/apache-artemis \
+        --user artemis \
+        --password simetraehcapa \
+        --cluster-user artemisCluster \
+        --cluster-password simetraehcaparetsulc ; \
+    else \
+      "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}/bin/artemis" create artemis \
+        --home /opt/apache-artemis \
+        --user artemis \
+        --password simetraehcapa \
+        --role amq \
+        --require-login \
+        --cluster-user artemisCluster \
+        --cluster-password simetraehcaparetsulc ; \
+    fi
+
+# Using KUBE_PING 0.9.3. Can't upgrade to 1.x.x as Artemis uses JGroups 3.3.x
+# https://github.com/jgroups-extras/jgroups-kubernetes/issues/30
+WORKDIR /opt/jgroupskubernetes
+RUN wget -O ivy-2.4.0.jar http://search.maven.org/remotecontent?filepath=org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar && \
+  java -jar ivy-2.4.0.jar -dependency org.jgroups.kubernetes kubernetes "${JGROUPS_KUBERNETES_VERSION}" -retrieve "[artifact]-[revision](-[classifier]).[ext]" -types jar && \
+  java -jar ivy-2.4.0.jar -dependency org.jgroups.kubernetes dns "${JGROUPS_KUBERNETES_VERSION}" -retrieve "[artifact]-[revision](-[classifier]).[ext]" -types jar && \
+  rm ivy-2.4.0.jar
+
+WORKDIR /var/lib/artemis/etc
+
+# Log to tty to enable docker logs container-name
+RUN sed -i "s/logger.handlers=.*/logger.handlers=CONSOLE/g" logging.properties
+
+# --java-options doesn't seem to work across the board on all versions adding them manually
+RUN sed -i "s/JAVA_ARGS=\"/JAVA_ARGS=\"-Djava.net.preferIPv4Addresses=true -Djava.net.preferIPv4Stack=true -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport/g" ../etc/artemis.profile
+
+# Ports are only exposed with an explicit argument, there is no need to binding
+# the web console to localhost
+RUN xmlstarlet ed -L -N amq="http://activemq.org/schema" \
+    -u "/amq:broker/amq:web/@bind" \
+    -v "http://0.0.0.0:8161" bootstrap.xml
+
+# In a similar fashion the jolokia access is restricted to localhost only. Disabling
+# this as in the natural environmnets for the image like Kubernetes this is problematic.
+RUN if (echo "${ACTIVEMQ_ARTEMIS_VERSION}" | grep -Eq  "(2.[^0-3]\\.[0-9]|[^1-2]\\.[0-9]\\.[0-9]+)" ) ; then xmlstarlet ed --inplace --subnode "/restrict" --type elem -n "remote" jolokia-access.xml && xmlstarlet ed --inplace --subnode "/restrict/remote" --type elem -n host -v "0.0.0.0/0" jolokia-access.xml; fi
+
+# Remove default values for memory in artemis profile in order to let the automatic
+# Java ergonomics detection work https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/ergonomics.html
+RUN sed -i "s/-Xm[xs][^ \"]*//g" ../etc/artemis.profile
+
+# For the casual run of the image make the docker-entrypoint-sh think
+# that the performance journal calibration is already completed
+RUN if (echo "${ACTIVEMQ_ARTEMIS_VERSION}" | grep -Eq  "(1.5\\.[3-5]|[^1]\\.[0-9]\\.[0-9]+)" ) ; then touch /var/lib/artemis/data/.perf-journal-completed; fi
+
+WORKDIR /opt/jmx-exporter
+RUN wget "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${JMX_EXPORTER_VERSION}/jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar" && \
+  wget "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${JMX_EXPORTER_VERSION}/jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar.sha1" && \
+  echo "$(cat "jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar.sha1")" "jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar" | sha1sum -c - && \
+  rm "jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar.sha1" && \
+  ln -s "/opt/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar" "/opt/jmx-exporter/jmx_prometheus_javaagent.jar"
+
+COPY assets/jmx-exporter-config.yaml /opt/jmx-exporter/etc/
+
+##########################################################
+## Run Image                                             #
+##########################################################
+ARG BASE_IMAGE
+# hadolint ignore=DL3006
+FROM $BASE_IMAGE
+LABEL maintainer="Victor Romero <victor.romero@gmail.com>"
+ARG ACTIVEMQ_ARTEMIS_VERSION
+ENV ACTIVEMQ_ARTEMIS_VERSION=$ACTIVEMQ_ARTEMIS_VERSION
+
+# add user and group for artemis
+RUN groupadd -g 1000 -r artemis && useradd -r -u 1000 -g artemis artemis
+
+RUN apt-get -qq -o=Dpkg::Use-Pty=0 update && \
+  apt-get -qq -o=Dpkg::Use-Pty=0 install -y --no-install-recommends \
+    libaio1=0.3.112-3 \
+    xmlstarlet=1.6.1-2 \
+    jq=1.5+dfsg-2+b1 \
+    gettext-base=0.19.8.1-9 \
+    dumb-init=1.2.2-1.1 \
+    procps=2:3.3.15-2 && \
+  rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}" "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}"
+COPY --from=builder "/var/lib/artemis" "/var/lib/artemis"
+COPY --from=builder "/opt/jmx-exporter" "/opt/jmx-exporter"
+COPY --from=builder "/opt/jgroupskubernetes/*" "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}/lib/"
+
+# To enable RESTORE_CONFIGURATION
+COPY --from=builder "/var/lib/artemis/etc" "/var/lib/artemis/etc-backup"
+
+RUN ln -s "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}" /opt/apache-artemis && chmod 755 /opt/apache-artemis
+RUN chown -R artemis.artemis /var/lib/artemis
+RUN chown -R artemis.artemis /opt/jmx-exporter
+
+RUN mkdir -p /opt/assets
+COPY assets/merge.xslt /opt/assets
+COPY assets/enable-jmx.xml /opt/assets
+
+# Web Server
+EXPOSE 8161
+
+# JMX Exporter
+EXPOSE 9404
+
+# Port for CORE,MQTT,AMQP,HORNETQ,STOMP,OPENWIRE
+EXPOSE 61616
+
+# Port for HORNETQ,STOMP
+EXPOSE 5445
+
+# Port for AMQP
+EXPOSE 5672
+
+# Port for MQTT
+EXPOSE 1883
+
+#Port for STOMP
+EXPOSE 61613
+
+WORKDIR /var/lib/artemis/bin
+
+USER artemis
+
+RUN mkdir /var/lib/artemis/lock
+
+# Expose some outstanding folders
+VOLUME ["/var/lib/artemis/data"]
+VOLUME ["/var/lib/artemis/tmp"]
+VOLUME ["/var/lib/artemis/etc"]
+VOLUME ["/var/lib/artemis/etc-override"]
+VOLUME ["/var/lib/artemis/lock"]
+VOLUME ["/opt/jmx-exporter/etc-override"]
+
+COPY assets/docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["artemis-server"]

--- a/tags.csv
+++ b/tags.csv
@@ -65,3 +65,4 @@ vromero/activemq-artemis,2.14.0,openjdk:8u232-jre-stretch,vromero/activemq-artem
 vromero/activemq-artemis,2.14.0-alpine,openjdk:8u212-jre-alpine3.9,vromero/activemq-artemis:2.14-alpine-latest,Dockerfile.alpine
 vromero/activemq-artemis,2.15.0,openjdk:8u232-jre-stretch,vromero/activemq-artemis:2.15-latest vromero/activemq-artemis:2-latest vromero/activemq-artemis:latest,Dockerfile
 vromero/activemq-artemis,2.15.0-alpine,openjdk:8u212-jre-alpine3.9,vromero/activemq-artemis:2.15-alpine-latest vromero/activemq-artemis:2-alpine-latest vromero/activemq-artemis:alpine-latest,Dockerfile.alpine
+vromero/activemq-artemis,2.15.0-jdk11,openjdk:11-jre-slim-buster,vromero/activemq-artemis:2.15-jdk11-latest vromero/activemq-artemis:2-jdk11-latest,Dockerfile.jdk11

--- a/test/assets/goss.yaml
+++ b/test/assets/goss.yaml
@@ -63,7 +63,7 @@ file:
     group: root
     filetype: symlink
     linked-to: /opt/apache-artemis-{{ .Env.ACTIVEMQ_ARTEMIS_VERSION }}
-  
+
   /opt/apache-artemis-{{ .Env.ACTIVEMQ_ARTEMIS_VERSION }}:
     exists: true
     owner: root
@@ -75,7 +75,7 @@ file:
     owner: artemis
     group: artemis
     filetype: directory
-  
+
   /var/lib/artemis/data:
     exists: true
     owner: artemis
@@ -131,21 +131,21 @@ file:
     group: artemis
     filetype: file
 {{if (getEnv "ARTEMIS_USERNAME") }}
-    contains: 
+    contains:
   {{ if and (getEnv "ACTIVEMQ_ARTEMIS_VERSION" "") (.Env.ACTIVEMQ_ARTEMIS_VERSION | regexMatch "1.[01].0") }}
       - /{{ .Env.ARTEMIS_USERNAME }} *= *amq/
   {{ else }}
       - /amq *= *{{ .Env.ARTEMIS_USERNAME }}/
   {{ end }}
 {{ else }}
-    contains: 
+    contains:
   {{ if and (getEnv "ACTIVEMQ_ARTEMIS_VERSION" "") (.Env.ACTIVEMQ_ARTEMIS_VERSION | regexMatch "1.[01].0") }}
       - /artemis *= *amq/
   {{ else }}
       - /amq *= *artemis/
   {{ end }}
 {{end}}
-  
+
 {{ if and (.Env.ACTIVEMQ_ARTEMIS_VERSION | regexMatch "(1.5.[^012]|[^1]\\.\\d+\\.\\d+)") (getEnv "ARTEMIS_PERF_JOURNAL" "AUTO" | regexMatch "AUTO") }}
   /var/lib/artemis/data/.perf-journal-completed:
     exists: true
@@ -162,8 +162,12 @@ file:
     contains:
       - "-Djava.net.preferIPv4Addresses=true"
       - "-XX:+UnlockExperimentalVMOptions"
+{{if regexMatch "jdk-8$" (getEnv "JAVA_HOME") }}
       - "-XX:+UseCGroupMemoryLimitForHeap"
       - "-XX:MaxRAMFraction=2"
+{{else}}
+      - "-XX:+UseContainerSupport"
+{{end}}
 {{if getEnv "JAVA_OPTS" }}
       - "-Djavax.net.ssl.keyStore=/var/lib/artemis/etc/keystore.jks"
       - "-Djavax.net.ssl.keyStorePassword=changeit"
@@ -171,14 +175,14 @@ file:
 {{if getEnv "ENABLE_JMX_EXPORTER" }}
       - "jmx_prometheus_javaagent.jar=9404"
 {{else}}
-      - "!jmx_prometheus_javaagent.jar"  
-{{end}} 
+      - "!jmx_prometheus_javaagent.jar"
+{{end}}
       - "$BROKER_CONFIGS"
 {{ if or (getEnv "ARTEMIS_MIN_MEMORY") (getEnv "ARTEMIS_MAX_MEMORY") (getEnv "ENABLE_JMX") }}
   {{if getEnv "ARTEMIS_MIN_MEMORY" }}
       - "-Xms{{ .Env.ARTEMIS_MIN_MEMORY }}"
   {{else}}
-      - "!-Xms"  
+      - "!-Xms"
   {{end}}
   {{if getEnv "ARTEMIS_MAX_MEMORY" }}
       - "-Xmx{{ .Env.ARTEMIS_MAX_MEMORY }}"


### PR DESCRIPTION
This PR adds support for a Java 11 based Artemis 2.15 Docker image. Also, this brings in Debian 10 (Buster) because the OpenJDK 11 image was built on top of it.

Closes #169